### PR TITLE
models: added type field to SocialMediaLink entity

### DIFF
--- a/src/models/SocialMediaLink.ts
+++ b/src/models/SocialMediaLink.ts
@@ -12,4 +12,7 @@ export class SocialMediaLink extends DefaultEntity {
 
 	@Column()
 	url: string;
+
+	@Column()
+	type: string;
 }


### PR DESCRIPTION
- type field works well with 'url' field as it sets what kind of link it is
- depends on the front-end's way of letting the user pick what type ( e.g. fb link, messenger link, telegram link, etc. )